### PR TITLE
SALG-1018: Prevent creating entities outside of a conference

### DIFF
--- a/web/modules/custom/os2conticki_content/src/Form/Helper.php
+++ b/web/modules/custom/os2conticki_content/src/Form/Helper.php
@@ -7,6 +7,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\node\NodeInterface;
 use Drupal\os2conticki_content\Helper\ConferenceHelper;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Form helper.
@@ -116,7 +117,9 @@ class Helper {
     }
 
     if (NULL === $conference) {
-      // @TODO We don't have a conference context. Clear the form and show a message instead.
+      $message = $this->t('Content of type @bundle must be created inside a conference.', ['@bundle' => $entity->bundle()]);
+      \Drupal::messenger()->addError($message);
+      throw new BadRequestHttpException($message);
     }
 
     // Store conference to be used by conference autocomplete.


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SALG-1018

It must not be possible to create entities outside of a conference. We have to find a good way to handle this. Currently we just report an error …