### PR TITLE
JOBCAMP-121: Update service worker when custom url is changed to point to another conference

### DIFF
--- a/web/modules/custom/os2conticki_app/src/Controller/ConferenceController.php
+++ b/web/modules/custom/os2conticki_app/src/Controller/ConferenceController.php
@@ -338,6 +338,11 @@ class ConferenceController extends ControllerBase implements ContainerInjectionI
     $appUrl = $node->field_custom_app_url->uri;
     if (NULL !== $path) {
       $appUrl = rtrim($appUrl, '/') . '/' . ltrim($path, '/');
+      // Add the conference id to the manifest url to make the service worker
+      // update if a custom url is changed to point to another conference.
+      if ('manifest' === $path) {
+        $appUrl .= (FALSE === strpos($appUrl, '?') ? '?' : '&') . 'id=' . $node->id();
+      }
     }
 
     return $appUrl;


### PR DESCRIPTION
https://jira.itkdev.dk/browse/JOBCAMP-121

This is an attempt at making the service worker update if a custom url is changed to point to another conference.
